### PR TITLE
fix 'window undefined' error thrown when using Next.js SSR

### DIFF
--- a/src/haveGamepadEvents.ts
+++ b/src/haveGamepadEvents.ts
@@ -1,4 +1,4 @@
 /**
  * Boolean to tell if browser supports gamepad events
  */
-export const haveGamepadEvents = 'ongamepadconnected' in window;
+export const haveGamepadEvents = (typeof window !== 'undefined') && ('ongamepadconnected' in window);


### PR DESCRIPTION
Corrects issue I ran into issue #1.

Adds additional logic to `haveGamepadEvents` boolean to avoid `window undefined` errors when using this library in server-side rendered components.

<img width="797" alt="image" src="https://github.com/nogiszd/react-ts-gamepads/assets/2039258/c62df2b9-2429-48ee-9b53-da577bb1c2a6">
